### PR TITLE
Remove version from composer.json and unused dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "yireo/magento2-extensionchecker",
   "license": "OSL-3.0",
   "type": "magento2-module",
-  "version": "1.1.1",
   "homepage": "https://github.com/yireo/Yireo_ExtensionChecker",
   "description": "Scan the code of a Magento module",
   "keywords": [
@@ -22,9 +21,6 @@
     "php": ">=7.0.0",
     "ext-json": "*",
     "ext-pcre": "*"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Remove version from composer.json because the git tag should be used instead.
- Remove PHPUnit from dev dependencies because it's unused