### PR TITLE
Notice on needlessly declared dependencies

### DIFF
--- a/Console/Command/ScanCommand.php
+++ b/Console/Command/ScanCommand.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Yireo ExtensionChecker for Magento
  *
@@ -8,8 +8,11 @@
  * @license     Open Source License (OSL v3)
  */
 
+declare(strict_types=1);
+
 namespace Yireo\ExtensionChecker\Console\Command;
 
+use Exception;
 use InvalidArgumentException;
 use ReflectionException;
 use Symfony\Component\Console\Command\Command;
@@ -69,6 +72,13 @@ class ScanCommand extends Command
             InputOption::VALUE_OPTIONAL,
             'Hide deprecated dependency notices'
         );
+
+        $this->addOption(
+            'hide-needless',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Hide needless dependency notices'
+        );
     }
 
     /**
@@ -88,11 +98,13 @@ class ScanCommand extends Command
         }
 
         $hideDeprecated = (bool)$input->getOption('hide-deprecated');
+        $hideNeedless = (bool)$input->getOption('hide-needless');
 
         $this->scan->setInput($input);
         $this->scan->setOutput($output);
         $this->scan->setModuleName($moduleName);
         $this->scan->setHideDeprecated($hideDeprecated);
+        $this->scan->setHideNeedless($hideNeedless);
 
         $hasWarnings = $this->scan->scan();
         return ($hasWarnings === true) ? 1 : 0;


### PR DESCRIPTION
This PR adds following feature:

- Show notices on declared dependencies that might actually not be needed. It consideres modules in module.xml, packages in composer.json and PHP extensions in composer.json. Since we cannot tell with 100% safety that a dependency is not needed, the notice states "possibly not needed". 
- Scenarios were a dependency is declared and is needed, but not found by the module are dependencies in method input arguments and return types, derived interfaces or classes, everything that is declared in xml (virtual types, plugins, blocks, ...) or just logical dependencies, like regulating the sort order of magento modules (e.g. a custom plugin needs to be executed before a plugin from another module, without referencing the module explicitely)
- On the other hand this feature can reduce dependency hell by showing actual unneeded dependencies
- This feature can be disabled by using the flag `--hide-needless`

The PR additionally enhances the notice when composer dependencies with version `*` are found. Similar to when a required dependency is not declared, now the current version is shown, so the developer can easily exchange the `*`