### PR TITLE
Allow Command to be run without installing Magento

### DIFF
--- a/Console/CommandList.php
+++ b/Console/CommandList.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\ExtensionChecker\Console;
+
+use Magento\Framework\ObjectManagerInterface;
+use Yireo\ExtensionChecker\Console\Command\ScanCommand;
+
+/**
+ * Provide list of CLI commands to be available for not-installed application
+ */
+class CommandList implements \Magento\Framework\Console\CommandListInterface
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Gets list of command classes
+     *
+     * @return string[]
+     */
+    private function getCommandsClasses(): array
+    {
+        return [ScanCommand::class];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCommands(): array
+    {
+        $commands = [];
+        foreach ($this->getCommandsClasses() as $class) {
+            if (class_exists($class)) {
+                $commands[] = $this->objectManager->get($class);
+            } else {
+                throw new \RuntimeException('Class ' . $class . ' does not exist');
+            }
+        }
+
+        return $commands;
+    }
+}

--- a/cli_commands.php
+++ b/cli_commands.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * This file is used to make some CLI commands available without Magento installation (deployment)
+ */
+if (PHP_SAPI === 'cli') {
+    \Magento\Framework\Console\CommandLocator::register(\Yireo\ExtensionChecker\Console\CommandList::class);
+}

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
       "Yireo\\ExtensionChecker\\": ""
     },
     "files": [
+      "cli_commands.php",
       "registration.php"
     ]
   }


### PR DESCRIPTION
Hej @jissereitsma! Long time no see,

I needed a possibility to run your command without running the whole Magento context.
So here I am, as others may also need it.

PS: I managed to execute the command for multiple modules in `app/code` with:
```shell
$ find app/code/ -maxdepth 2 -mindepth 2 -type d | grep -oP '[A-Za-z]+/[A-Za-z]+$' | tr '/' '_' | xargs -L1 bin/magento yireo_extensionchecker:scan --module
```