### PR TITLE
Removed random return in ClassInspector.php

### DIFF
--- a/PhpClass/ClassInspector.php
+++ b/PhpClass/ClassInspector.php
@@ -103,7 +103,6 @@ class ClassInspector
         }
 
         $dependencies = array_merge($dependencies, $this->getDependenciesFromConstructor());
-        return $dependencies;
         $dependencies = array_merge($dependencies, $this->getImplementedInterfaceNames());
 
         $importedClasses = $this->tokenizer->getImportedClassnamesFromFile($this->getFilename());


### PR DESCRIPTION
Removed a random return statement in the getDependencies function that caused a lot of dependencies te be missing from the list.