### PR TITLE
Replace class dependency to support <= PHP7.2.5

### DIFF
--- a/Console/Command/InspectClassCommand.php
+++ b/Console/Command/InspectClassCommand.php
@@ -11,12 +11,12 @@
 
 namespace Yireo\ExtensionChecker\Console\Command;
 
-use Composer\Console\Input\InputArgument;
 use InvalidArgumentException;
 use Magento\Framework\Serialize\SerializerInterface;
 use ReflectionException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface as Output;


### PR DESCRIPTION
Replaces `Composer\Console\Input\InputArgument` (which is requires PHP7.2.5+) by `Symfony\Component\Console\Input\InputArgument` to support Magento <= 2.4.5-p8

This fix ```Class "Composer\Console\Input\InputArgument" not found#0 /var/www/html/vendor/symfony/console/Command/Command.php(77): Yireo\ExtensionChecker\Console\Command\InspectClassCommand->configure()```